### PR TITLE
fix (gwip): don't gpgsign WIP commit

### DIFF
--- a/git-commands.sh
+++ b/git-commands.sh
@@ -1150,7 +1150,7 @@ function git_wip() {
   git_cmd_help $1 && return
 
   git_cmd add -A
-  git_cmd commit --no-verify -m "WIP"
+  git_cmd -c commit.gpgsign=false commit --no-verify -m "WIP"
 }
 alias gwip='git_wip'
 


### PR DESCRIPTION
Modify the `gwip` command to disable gpgsigning for WIP commits. The `-c` flag only modifies the local git config temporarily for this command.